### PR TITLE
feat(server): 添加 pprof 性能分析工具

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,17 +137,17 @@ clean:
 .PHONY: houyi
 # local run houyi
 houyi:
-	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/houyi/houyi/cmd.go -c cmd/server/houyi/configs
+	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/houyi/houyi/cmd.go -c cmd/server/houyi/configs -pprof_address 0.0.0.0:6062
 
 .PHONY: rabbit
 # local run rabbit
 rabbit:
-	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/rabbit/rabbit/cmd.go -c cmd/server/rabbit/configs
+	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/rabbit/rabbit/cmd.go -c cmd/server/rabbit/configs -pprof_address 0.0.0.0:6061
 
 .PHONY: palace
 # local run palace
 palace:
-	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/palace/palace/cmd.go -c cmd/server/palace/configs
+	go run -ldflags "-X main.Version=$(VERSION)" cmd/server/palace/palace/cmd.go -c cmd/server/palace/configs -pprof_address 0.0.0.0:6060
 
 # show help
 help:

--- a/api/admin/authorization/authorization.proto
+++ b/api/admin/authorization/authorization.proto
@@ -72,7 +72,7 @@ service Authorization {
   // 展示oauth列表
   rpc ListOauth (ListOauthRequest) returns (ListOauthReply) {
     option (google.api.http) = {
-      get: "/v1/authorization/oauth"
+      get: "/v1/authorization/oauths"
     };
   }
 

--- a/api/enum.proto
+++ b/api/enum.proto
@@ -394,14 +394,14 @@ enum InviteType {
   INVITE_TYPE_REJECTED = 3;
 }
 
-enum SendStatus{
+enum SendStatus {
   SEND_STATUS_UNKNOWN = 0;
   Sending = 1;
   SentSuccess = 2;
   SendFail = 3;
 }
 
-enum AlarmSendType{
+enum AlarmSendType {
   AlarmSend_Type_UNKNOWN = 0;
   Alarm_Send_Type_Email = 1;
   Alarm_Send_Type_SMS = 2;
@@ -410,7 +410,7 @@ enum AlarmSendType{
   Alarm_Send_Type_Wechat = 5;
 }
 
-enum StrategyType{
+enum StrategyType {
   // 未知
   StrategyTypeUnknown = 0;
   // Metric

--- a/cmd/server/houyi/houyi/cmd.go
+++ b/cmd/server/houyi/houyi/cmd.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	_ "net/http/pprof"
+
 	_ "go.uber.org/automaxprocs"
 
 	"flag"
@@ -19,15 +22,25 @@ var (
 
 	// Version is the version of the compiled software.
 	Version string
+
+	// pprofAddress is the pprof address.
+	pprofAddress string
 )
 
 func init() {
 	flag.StringVar(&flagconf, "c", "../configs", "config path, eg: -c ./configs")
 	flag.StringVar(&configType, "config_ext", "yaml", "config file ext name, eg: -config_ext yaml")
+	flag.StringVar(&pprofAddress, "pprof_address", "", "pprof address, eg: -pprof_address 0.0.0.0:6060")
 }
 
 func main() {
 	flag.Parse()
 	env.SetVersion(Version)
+
+	go func() {
+		if pprofAddress != "" {
+			http.ListenAndServe(pprofAddress, nil)
+		}
+	}()
 	houyi.Run(flagconf, configType)
 }

--- a/cmd/server/palace/configs/config.yaml
+++ b/cmd/server/palace/configs/config.yaml
@@ -29,6 +29,7 @@ jwt:
     - /api.admin.authorization.Authorization/VerifyEmail
     - /api.admin.authorization.Authorization/SetEmailWithLogin
     - /api.admin.authorization.Authorization/ListOauth
+    - /api.admin.authorization.Authorization/RegisterWithEmail
 
 cache:
   driver: 'free'

--- a/cmd/server/palace/internal/data/repoimpl/strategy.go
+++ b/cmd/server/palace/internal/data/repoimpl/strategy.go
@@ -705,7 +705,11 @@ func (s *strategyRepositoryImpl) GetStrategyMetricLevels(ctx context.Context, st
 	if !types.IsNil(err) {
 		return nil, err
 	}
-	return bizQuery.WithContext(ctx).StrategyMetricsLevel.Where(bizQuery.StrategyMetricsLevel.StrategyID.In(strategyIds...)).Find()
+	return bizQuery.WithContext(ctx).
+		StrategyMetricsLevel.
+		Where(bizQuery.StrategyMetricsLevel.StrategyID.In(strategyIds...)).
+		Preload(field.Associations).
+		Find()
 }
 
 // GetStrategyMQLevels 获取MQ策略等级
@@ -714,7 +718,11 @@ func (s *strategyRepositoryImpl) GetStrategyMQLevels(ctx context.Context, strate
 	if !types.IsNil(err) {
 		return nil, err
 	}
-	return bizQuery.WithContext(ctx).StrategyMQLevel.Preload(field.Associations).Where(bizQuery.StrategyMQLevel.StrategyID.In(strategyIds...)).Find()
+	return bizQuery.WithContext(ctx).
+		StrategyMQLevel.
+		Where(bizQuery.StrategyMQLevel.StrategyID.In(strategyIds...)).
+		Preload(field.Associations).
+		Find()
 }
 
 func createStrategyMetricLevelParamsToModel(ctx context.Context, params []*bo.CreateStrategyMetricLevel, strategyID uint32) []*bizmodel.StrategyMetricsLevel {

--- a/cmd/server/palace/palace/cmd.go
+++ b/cmd/server/palace/palace/cmd.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	_ "go.uber.org/automaxprocs"
-
 	"flag"
+	"net/http"
+	_ "net/http/pprof"
+
+	_ "go.uber.org/automaxprocs"
 
 	"github.com/aide-family/moon/cmd/server/palace"
 	"github.com/aide-family/moon/pkg/env"
@@ -19,15 +21,24 @@ var (
 
 	// Version is the version of the compiled software.
 	Version string
+
+	// pprofAddress is the pprof address.
+	pprofAddress string
 )
 
 func init() {
 	flag.StringVar(&flagconf, "c", "../configs", "config path, eg: -c ./configs")
 	flag.StringVar(&configType, "config_ext", "yaml", "config file ext name, eg: -config_ext yaml")
+	flag.StringVar(&pprofAddress, "pprof_address", "", "pprof address, eg: -pprof_address 0.0.0.0:6060")
 }
 
 func main() {
 	flag.Parse()
 	env.SetVersion(Version)
+	go func() {
+		if pprofAddress != "" {
+			http.ListenAndServe(pprofAddress, nil)
+		}
+	}()
 	palace.Run(flagconf, configType)
 }

--- a/cmd/server/rabbit/rabbit/cmd.go
+++ b/cmd/server/rabbit/rabbit/cmd.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	_ "net/http/pprof"
+
 	_ "go.uber.org/automaxprocs"
 
 	"flag"
+	"net/http"
 
 	"github.com/aide-family/moon/cmd/server/rabbit"
 	"github.com/aide-family/moon/pkg/env"
@@ -19,15 +22,24 @@ var (
 
 	// Version is the version of the compiled software.
 	Version string
+
+	// pprofAddress is the pprof address.
+	pprofAddress string
 )
 
 func init() {
 	flag.StringVar(&flagconf, "c", "../configs", "config path, eg: -c ./configs")
 	flag.StringVar(&configType, "config_ext", "yaml", "config file ext name, eg: -config_ext yaml")
+	flag.StringVar(&pprofAddress, "pprof_address", "", "pprof address, eg: -pprof_address 0.0.0.0:6060")
 }
 
 func main() {
 	flag.Parse()
 	env.SetVersion(Version)
+	go func() {
+		if pprofAddress != "" {
+			http.ListenAndServe(pprofAddress, nil)
+		}
+	}()
 	rabbit.Run(flagconf, configType)
 }

--- a/deploy/docker/moon/palace/config.yaml
+++ b/deploy/docker/moon/palace/config.yaml
@@ -29,6 +29,7 @@ jwt:
     - /api.admin.authorization.Authorization/VerifyEmail
     - /api.admin.authorization.Authorization/SetEmailWithLogin
     - /api.admin.authorization.Authorization/ListOauth
+    - /api.admin.authorization.Authorization/RegisterWithEmail
 
 cache:
   driver: 'redis'

--- a/deploy/k8s/moon/palace/configmap.yaml
+++ b/deploy/k8s/moon/palace/configmap.yaml
@@ -36,6 +36,7 @@ data:
         - /api.admin.authorization.Authorization/VerifyEmail
         - /api.admin.authorization.Authorization/SetEmailWithLogin
         - /api.admin.authorization.Authorization/ListOauth
+        - /api.admin.authorization.Authorization/RegisterWithEmail
 
     cache:
       driver: "redis"

--- a/pkg/watch/queue.go
+++ b/pkg/watch/queue.go
@@ -1,7 +1,7 @@
 package watch
 
 // QueueMaxSize 默认消息队列最大长度
-const QueueMaxSize = 1 << 32
+const QueueMaxSize = 1 << 10
 
 // NewDefaultQueue 定义接收消息和发送消息的消息队列
 func NewDefaultQueue(size int) Queue {


### PR DESCRIPTION
- 在 houyi、palace 和 rabbit 服务中添加 pprof 支持- 新增 -pprof_address 命令行参数用于指定 pprof 监听地址
- 在 Makefile 中更新本地运行命令，添加 pprof 监听端口
- 调整消息队列最大长度为 1024
