### PR TITLE
feat(monitor): 添加告警和通知的监控指标

### DIFF
--- a/cmd/server/palace/internal/data/data.go
+++ b/cmd/server/palace/internal/data/data.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/aide-family/moon/cmd/server/palace/internal/palaceconf"
 	"github.com/aide-family/moon/pkg/conf"
@@ -16,6 +15,7 @@ import (
 	"github.com/aide-family/moon/pkg/util/conn"
 	"github.com/aide-family/moon/pkg/util/conn/rbac"
 	"github.com/aide-family/moon/pkg/util/email"
+	"github.com/aide-family/moon/pkg/util/safety"
 	"github.com/aide-family/moon/pkg/util/types"
 	"github.com/aide-family/moon/pkg/watch"
 
@@ -38,9 +38,9 @@ type Data struct {
 	alarmDB      *sql.DB
 	bizDB        *sql.DB
 	cacher       cache.ICacher
-	enforcerMap  *sync.Map
-	teamBizDBMap *sync.Map
-	alarmDBMap   *sync.Map
+	enforcerMap  *safety.Map[uint32, *casbin.SyncedEnforcer]
+	teamBizDBMap *safety.Map[uint32, *gorm.DB]
+	alarmDBMap   *safety.Map[uint32, *gorm.DB]
 
 	ossClient oss.Client
 	ossConf   *conf.Oss
@@ -70,9 +70,9 @@ func NewData(c *palaceconf.Bootstrap) (*Data, func(), error) {
 	d := &Data{
 		bizDatabaseConf:         bizConf,
 		alarmDatabaseConf:       alarmConf,
-		teamBizDBMap:            new(sync.Map),
-		alarmDBMap:              new(sync.Map),
-		enforcerMap:             new(sync.Map),
+		teamBizDBMap:            safety.NewMap[uint32, *gorm.DB](),
+		alarmDBMap:              safety.NewMap[uint32, *gorm.DB](),
+		enforcerMap:             safety.NewMap[uint32, *casbin.SyncedEnforcer](),
 		strategyQueue:           watch.NewDefaultQueue(watch.QueueMaxSize),
 		alertQueue:              watch.NewDefaultQueue(watch.QueueMaxSize),
 		alertPersistenceDBQueue: watch.NewDefaultQueue(watch.QueueMaxSize),
@@ -115,16 +115,11 @@ func NewData(c *palaceconf.Bootstrap) (*Data, func(), error) {
 		}
 		d.alarmDB = db
 		closeFuncList = append(closeFuncList, func() {
-			log.Debugw("close alarm db", d.bizDB.Close())
-			d.alarmDBMap.Range(func(key, value any) bool {
-				alarmDB, ok := value.(*gorm.DB)
-				if !ok {
-					return true
-				}
-				dbTmp, _ := alarmDB.DB()
-				log.Debugw("close alarm orm db", key, "err", dbTmp.Close())
-				return ok
-			})
+			log.Debugw("msg", "close alarm db", "err", d.bizDB.Close())
+			for _, value := range d.alarmDBMap.List() {
+				dbTmp, _ := value.DB()
+				log.Debugw("msg", "close alarm orm db", "err", dbTmp.Close())
+			}
 		})
 	}
 
@@ -139,16 +134,11 @@ func NewData(c *palaceconf.Bootstrap) (*Data, func(), error) {
 
 		d.bizDB = db
 		closeFuncList = append(closeFuncList, func() {
-			log.Debugw("close biz db", d.bizDB.Close())
-			d.teamBizDBMap.Range(func(key, value any) bool {
-				teamBizDB, ok := value.(*gorm.DB)
-				if !ok {
-					return true
-				}
-				dbTmp, _ := teamBizDB.DB()
-				log.Debugw("close biz orm db", key, "err", dbTmp.Close())
-				return ok
-			})
+			log.Debugw("msg", "close biz db", "err", d.bizDB.Close())
+			for _, value := range d.teamBizDBMap.List() {
+				teamBizDB, _ := value.DB()
+				log.Debugw("msg", "close biz orm db", "err", teamBizDB.Close())
+			}
 		})
 	}
 
@@ -286,13 +276,9 @@ func (d *Data) GetBizGormDB(teamID uint32) (*gorm.DB, error) {
 			"teamID": strconv.FormatUint(uint64(teamID), 10),
 		})
 	}
-	dbValue, exist := d.teamBizDBMap.Load(teamID)
+	bizDB, exist := d.teamBizDBMap.Get(teamID)
 	if exist {
-		bizDB, isBizDB := dbValue.(*gorm.DB)
-		if isBizDB {
-			return bizDB, nil
-		}
-		return nil, merr.ErrorNotification("数据库服务异常")
+		return bizDB, nil
 	}
 	dsn := genBizDatabaseName(teamID)
 	driver := strings.ToLower(d.bizDatabaseConf.GetDriver())
@@ -314,13 +300,13 @@ func (d *Data) GetBizGormDB(teamID uint32) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	d.teamBizDBMap.Store(teamID, bizDB)
+	d.teamBizDBMap.Set(teamID, bizDB)
 	enforcer, err := rbac.InitCasbinModel(bizDB)
 	if !types.IsNil(err) {
 		log.Errorw("casbin", "init error", "err", err)
 		return nil, err
 	}
-	d.enforcerMap.Store(teamID, enforcer)
+	d.enforcerMap.Set(teamID, enforcer)
 	return bizDB, nil
 }
 
@@ -329,13 +315,9 @@ func (d *Data) GetAlarmGormDB(teamID uint32) (*gorm.DB, error) {
 	if teamID == 0 {
 		return nil, merr.ErrorI18nToastTeamNotFound(context.Background())
 	}
-	dbValue, exist := d.alarmDBMap.Load(teamID)
+	dbValue, exist := d.alarmDBMap.Get(teamID)
 	if exist {
-		bizDB, isBizDB := dbValue.(*gorm.DB)
-		if isBizDB {
-			return bizDB, nil
-		}
-		return nil, merr.ErrorNotification("数据库服务异常")
+		return dbValue, nil
 	}
 
 	dsn := genAlarmDatabaseName(teamID)
@@ -357,8 +339,7 @@ func (d *Data) GetAlarmGormDB(teamID uint32) (*gorm.DB, error) {
 	if !types.IsNil(err) {
 		return nil, err
 	}
-
-	d.alarmDBMap.Store(teamID, bizDB)
+	d.alarmDBMap.Set(teamID, bizDB)
 	return bizDB, nil
 }
 
@@ -385,18 +366,15 @@ func (d *Data) GetCasBin(teamID uint32, tx ...*gorm.DB) *casbin.SyncedEnforcer {
 	if len(tx) > 0 {
 		return d.GetCasbinByTx(tx[0])
 	}
-	enforceVal, exist := d.enforcerMap.Load(teamID)
+	enforceVal, exist := d.enforcerMap.Get(teamID)
 	if !exist {
 		_, err := d.GetBizGormDB(teamID)
 		if !types.IsNil(err) {
 			panic(err)
 		}
+		return d.GetCasBin(teamID)
 	}
-	enforce, ok := enforceVal.(*casbin.SyncedEnforcer)
-	if !ok {
-		panic("enforcer not found")
-	}
-	return enforce
+	return enforceVal
 }
 
 // newCache 创建缓存

--- a/cmd/server/palace/internal/data/init.go
+++ b/cmd/server/palace/internal/data/init.go
@@ -910,6 +910,14 @@ var resourceList = []*model.SysAPI{
 		Status: vobj.StatusEnable,
 		Allow:  vobj.AllowRBAC,
 	},
+	// 策略推送
+	{
+		Name:   "策略推送",
+		Path:   "/api.admin.strategy.Strategy/PushStrategy",
+		Remark: "策略推送， 用于策略推送",
+		Status: vobj.StatusEnable,
+		Allow:  vobj.AllowRBAC,
+	},
 	// 策略模版管理
 	// 创建策略模版
 	{

--- a/cmd/server/palace/internal/data/microserver/send_alert.go
+++ b/cmd/server/palace/internal/data/microserver/send_alert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aide-family/moon/cmd/server/palace/internal/biz/repository"
 	"github.com/aide-family/moon/cmd/server/palace/internal/data"
 	"github.com/aide-family/moon/cmd/server/palace/internal/service/builder"
+	"github.com/aide-family/moon/pkg/helper/metric"
 	"github.com/aide-family/moon/pkg/merr"
 	"github.com/aide-family/moon/pkg/util/after"
 	"github.com/aide-family/moon/pkg/util/types"
@@ -89,8 +90,12 @@ func (s *sendAlertRepositoryImpl) alarmSendHistorySave(ctx context.Context, send
 	routeParts := strings.Split(route, "_")
 	// 检查route是否合法
 	if len(routeParts) != 3 {
-		return merr.ErrorI18nParameterRelatedAlarmSendingAndReceivingParametersAreInvalid(ctx)
+		log.Warnf("route is invalid: %s", merr.ErrorI18nParameterRelatedAlarmSendingAndReceivingParametersAreInvalid(ctx))
+		return nil
 	}
+	teamID := routeParts[1]
+	notifyID := routeParts[2]
+	metric.IncNotifyCounter(teamID, status.EnString(), notifyID)
 	// 解析告警team_id
 	param.TeamID = getTeamIDByRoute(routeParts)
 	// 解析告警组id

--- a/pkg/conf/conf.pb.go
+++ b/pkg/conf/conf.pb.go
@@ -7,12 +7,11 @@
 package conf
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/pkg/helper/metric/counter_alarm.go
+++ b/pkg/helper/metric/counter_alarm.go
@@ -1,0 +1,27 @@
+package metric
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var alarmCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "",
+		Subsystem: "",
+		Name:      "alarm_total",
+		Help:      "count of alarm",
+	},
+	[]string{"level_id", "strategy_id", "team_id"},
+)
+
+func init() {
+	prometheus.MustRegister(alarmCounter)
+}
+
+// IncAlarmCounter 告警计数器+1
+func IncAlarmCounter(levelID, strategyID, teamID string) {
+	alarmCounter.WithLabelValues(levelID, strategyID, teamID).Inc()
+}
+
+// AddAlarmCounter 告警计数器+n
+func AddAlarmCounter(levelID, strategyID, teamID string, n float64) {
+	alarmCounter.WithLabelValues(levelID, strategyID, teamID).Add(n)
+}

--- a/pkg/helper/metric/counter_notify.go
+++ b/pkg/helper/metric/counter_notify.go
@@ -1,0 +1,22 @@
+package metric
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var notifyCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "",
+		Subsystem: "",
+		Name:      "notify_total",
+		Help:      "count of notify",
+	},
+	[]string{"team_id", "status", "notify_id"},
+)
+
+func init() {
+	prometheus.MustRegister(notifyCounter)
+}
+
+// IncNotifyCounter 通知计数器+1
+func IncNotifyCounter(teamID, notifyStatus, notifyID string) {
+	notifyCounter.WithLabelValues(teamID, notifyStatus, notifyID).Inc()
+}

--- a/pkg/helper/metric/gauge_alarm.go
+++ b/pkg/helper/metric/gauge_alarm.go
@@ -1,0 +1,27 @@
+package metric
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var alarmGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "",
+		Subsystem: "",
+		Name:      "alarm_realtime_total",
+		Help:      "count of alarm",
+	},
+	[]string{"level_id", "strategy_id", "team_id"},
+)
+
+func init() {
+	prometheus.MustRegister(alarmGauge)
+}
+
+// IncAlarmGauge 告警计数器+1
+func IncAlarmGauge(levelID, strategyID, teamID string) {
+	alarmGauge.WithLabelValues(levelID, strategyID, teamID).Inc()
+}
+
+// DecAlarmGauge 告警计数器-1
+func DecAlarmGauge(levelID, strategyID, teamID string) {
+	alarmGauge.WithLabelValues(levelID, strategyID, teamID).Dec()
+}

--- a/pkg/helper/middleware/jwt_test.go
+++ b/pkg/helper/middleware/jwt_test.go
@@ -42,3 +42,13 @@ func TestNewJwtClaims(t *testing.T) {
 	}
 	t.Log(token)
 }
+
+func TestParseJwtClaimsFromToken(t *testing.T) {
+	SetSignKey("moon-sign_key")
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoyLCJ0ZWFtIjozMCwibWVtYmVyIjoxLCJpc3MiOiJtb29uLXBhbGFjZSIsImV4cCI6MTczNjMzMTg1OX0.PdAIRvDphKRe6haL8DtSrAfYZ-bGUv75-rPB1cMkIqc"
+	claims, ok := ParseJwtClaimsFromToken(token)
+	t.Log(claims)
+	if !ok {
+		t.Fatal("failed to parse jwt claims from token")
+	}
+}

--- a/pkg/helper/sse/client.go
+++ b/pkg/helper/sse/client.go
@@ -1,0 +1,78 @@
+package sse
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+// NewClient creates a new client
+func NewClient(id uint32) *Client {
+	return &Client{
+		ID:   id,
+		Send: make(chan []byte, 10),
+	}
+}
+
+// Client is a client of the SSE server
+type Client struct {
+	ID   uint32
+	Send chan []byte
+}
+
+// NewClientManager creates a new client manager
+func NewClientManager() *ClientManager {
+	return &ClientManager{
+		clients: make(map[uint32]*Client),
+	}
+}
+
+type ClientManager struct {
+	clients map[uint32]*Client
+	mu      sync.RWMutex
+}
+
+// AddClient adds a client to the manager
+func (cm *ClientManager) AddClient(client *Client) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if _, ok := cm.clients[client.ID]; ok {
+		return
+	}
+	cm.clients[client.ID] = client
+}
+
+// RemoveClient removes a client from the manager
+func (cm *ClientManager) RemoveClient(id uint32) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	delete(cm.clients, id)
+}
+
+// GetClient returns a client by id
+func (cm *ClientManager) GetClient(id uint32) (*Client, bool) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	client, ok := cm.clients[id]
+	return client, ok
+}
+
+// WriteSSE writes data to the client
+func (c *Client) WriteSSE(w http.ResponseWriter) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		log.Errorw("err", "Streaming unsupported!")
+		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
+		return
+	}
+	log.Debugw("msg", "listen sse client")
+	for data := range c.Send {
+		log.Debugw("WriteSSE", string(data))
+		fmt.Fprintf(w, "data: %s\n\n", string(data))
+		flusher.Flush()
+	}
+	fmt.Fprintf(w, "data: [DONE]\n\n")
+	log.Debugw("WriteSSE", "data: [DONE]")
+}

--- a/pkg/helper/sse/sse.go
+++ b/pkg/helper/sse/sse.go
@@ -1,0 +1,57 @@
+package sse
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/aide-family/moon/pkg/helper/middleware"
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+var ErrClientNotFound = errors.New("client not found")
+
+var clientManager *ClientManager
+
+func init() {
+	clientManager = NewClientManager()
+}
+
+// HandleSSE handles the SSE connection
+func HandleSSE(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		http.Error(w, "token is required", http.StatusBadRequest)
+		return
+	}
+	// 设置HTTP头部，指定这是一个SSE连接
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	claims, ok := middleware.ParseJwtClaimsFromToken(token)
+	if !ok {
+		http.Error(w, "token is invalid", http.StatusUnauthorized)
+		return
+	}
+
+	client := NewClient(claims.UserID)
+	clientManager.AddClient(client)
+	defer func() {
+		clientManager.RemoveClient(client.ID)
+		close(client.Send)
+	}()
+
+	go client.WriteSSE(w)
+	<-r.Context().Done()
+	log.Infof("client %d disconnected", client.ID)
+}
+
+// SendMessage sends a message to the client
+func SendMessage(id uint32, message string) error {
+	client, ok := clientManager.GetClient(id)
+	if !ok {
+		return ErrClientNotFound
+	}
+	client.Send <- []byte(message)
+	return nil
+}

--- a/pkg/helper/sse/sse.html
+++ b/pkg/helper/sse/sse.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SSE Client</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+        }
+        #messages {
+            margin-top: 20px;
+            border: 1px solid #ccc;
+            padding: 10px;
+            max-height: 300px;
+            overflow-y: auto;
+        }
+    </style>
+</head>
+<body>
+<h1>Server-Sent Events (SSE) Client</h1>
+<div>
+    <label for="token">Enter your Token: </label>
+    <input type="text" id="token" placeholder="e.g., user1">
+    <button onclick="connectToSSE()">Connect</button>
+</div>
+<div></div>
+    <label for="message">Enter your Message: </label>
+    <input type="text" id="message" placeholder="e.g., hello">
+    <button onclick="sendMessage()">Send</button>
+</div>
+<div id="messages"></div>
+
+<script>
+    let eventSource = null;
+
+    function connectToSSE() {
+        const token = document.getElementById('token').value;
+        if (!token) {
+            alert("Please enter a Token.");
+            return;
+        }
+
+        // 创建一个EventSource对象，连接到服务器的SSE端点
+        if (eventSource) {
+            eventSource.close(); // 如果已存在连接，先关闭之前的连接
+        }
+
+        const url = new URL(`http://localhost:9999/events`);
+        url.searchParams.set("token", token);
+        eventSource = new EventSource(url.toString());
+
+        eventSource.onmessage = function(event) {
+            const messagesDiv = document.getElementById('messages');
+            const newMessage = document.createElement('div');
+            newMessage.textContent = `New message: ${event.data}`;
+            messagesDiv.appendChild(newMessage);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight; // 自动滚动到最新消息
+        };
+
+        eventSource.onerror = function() {
+            alert("Error connecting to server.");
+            eventSource.close();
+        };
+
+        eventSource.onopen = function() {
+            console.log("SSE connection established.");
+        };
+    }
+
+
+
+    function sendMessage() {
+        const message = document.getElementById('message').value;
+        if (!message) {
+            alert("Please enter a message.");
+            return;
+        }
+        fetch(`/msg?msg=${message}`, {
+            method: 'GET',
+        });
+    }
+</script>
+</body>
+</html>

--- a/pkg/helper/sse/sse_test.go
+++ b/pkg/helper/sse/sse_test.go
@@ -1,0 +1,28 @@
+package sse
+
+import (
+	_ "embed"
+	"net/http"
+	"testing"
+
+	"github.com/aide-family/moon/pkg/helper/middleware"
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+//go:embed sse.html
+var sseHtml string
+
+func TestHandleSSE(t *testing.T) {
+	middleware.SetSignKey("moon-sign_key")
+	http.HandleFunc("/events", HandleSSE)
+	http.HandleFunc("/msg", func(writer http.ResponseWriter, request *http.Request) {
+		msg := request.URL.Query().Get("msg")
+		log.Debugw("msg", msg)
+		SendMessage(2, msg)
+	})
+	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte(sseHtml))
+	})
+
+	http.ListenAndServe(":9999", nil)
+}

--- a/pkg/merr/err.pb.go
+++ b/pkg/merr/err.pb.go
@@ -7,12 +7,11 @@
 package merr
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	_ "github.com/go-kratos/kratos/v2/errors"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/pkg/merr/err_errors.pb.go
+++ b/pkg/merr/err_errors.pb.go
@@ -5,7 +5,6 @@ package merr
 import (
 	context "context"
 	fmt "fmt"
-
 	errors "github.com/go-kratos/kratos/v2/errors"
 	i18n "github.com/nicksnyder/go-i18n/v2/i18n"
 )
@@ -80,8 +79,7 @@ var _AlertMsg = &i18n.Message{
 }
 
 // ErrorI18nAlert 用于表单验证错误
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nAlert(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "参数错误"
 	if len(args) > 0 {
@@ -145,10 +143,9 @@ var _AlertCreateAlarmGroupRequestNameLenMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertCreateAlarmGroupRequestNameLen 用于表单验证错误
-//
-//	CreateAlarmGroupRequest_Name_Len
-//	用户名错误
-//	支持国际化输出
+//  CreateAlarmGroupRequest_Name_Len
+//  用户名错误
+//  支持国际化输出
 func ErrorI18nAlertCreateAlarmGroupRequestNameLen(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "用户名错误"
 	if len(args) > 0 {
@@ -214,10 +211,9 @@ var _AlertCreateAlarmGroupRequestRemarkLenMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertCreateAlarmGroupRequestRemarkLen 用于表单验证错误
-//
-//	CreateAlarmGroupRequest_Remark_Len
-//	告警组说明长度限制在0-200个字符
-//	支持国际化输出
+//  CreateAlarmGroupRequest_Remark_Len
+//  告警组说明长度限制在0-200个字符
+//  支持国际化输出
 func ErrorI18nAlertCreateAlarmGroupRequestRemarkLen(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警组说明长度限制在0-200个字符"
 	if len(args) > 0 {
@@ -283,10 +279,9 @@ var _AlertPasswordErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertPasswordErr 用于表单验证错误
-//
-//	PASSWORD_ERR
-//	密码错误
-//	支持国际化输出
+//  PASSWORD_ERR
+//  密码错误
+//  支持国际化输出
 func ErrorI18nAlertPasswordErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "密码错误"
 	if len(args) > 0 {
@@ -352,10 +347,9 @@ var _AlertPasswordSameErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertPasswordSameErr 用于表单验证错误
-//
-//	PASSWORD_SAME_ERR
-//	新旧密码不能相同
-//	支持国际化输出
+//  PASSWORD_SAME_ERR
+//  新旧密码不能相同
+//  支持国际化输出
 func ErrorI18nAlertPasswordSameErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "新旧密码不能相同"
 	if len(args) > 0 {
@@ -421,10 +415,9 @@ var _AlertTeamNameExistErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertTeamNameExistErr 用于表单验证错误
-//
-//	TEAM_NAME_EXIST_ERR
-//	团队名称已存在
-//	支持国际化输出
+//  TEAM_NAME_EXIST_ERR
+//  团队名称已存在
+//  支持国际化输出
 func ErrorI18nAlertTeamNameExistErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "团队名称已存在"
 	if len(args) > 0 {
@@ -490,10 +483,9 @@ var _AlertCaptchaErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertCaptchaErr 用于表单验证错误
-//
-//	CAPTCHA_ERR
-//	验证码错误
-//	支持国际化输出
+//  CAPTCHA_ERR
+//  验证码错误
+//  支持国际化输出
 func ErrorI18nAlertCaptchaErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "验证码错误"
 	if len(args) > 0 {
@@ -559,10 +551,9 @@ var _AlertCaptchaExpireMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertCaptchaExpire 用于表单验证错误
-//
-//	CAPTCHA_EXPIRE
-//	验证码已过期
-//	支持国际化输出
+//  CAPTCHA_EXPIRE
+//  验证码已过期
+//  支持国际化输出
 func ErrorI18nAlertCaptchaExpire(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "验证码已过期"
 	if len(args) > 0 {
@@ -628,10 +619,9 @@ var _AlertStrategyGroupNotEnableMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyGroupNotEnable 用于表单验证错误
-//
-//	STRATEGY_GROUP_NOT_ENABLE
-//	策略组[%s]未启用, 不允许开启策略[%s]
-//	支持国际化输出
+//  STRATEGY_GROUP_NOT_ENABLE
+//  策略组[%s]未启用, 不允许开启策略[%s]
+//  支持国际化输出
 func ErrorI18nAlertStrategyGroupNotEnable(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略组[%s]未启用, 不允许开启策略[%s]"
 	if len(args) > 0 {
@@ -697,10 +687,9 @@ var _AlertAlertObjectDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertObjectDuplicate 用于表单验证错误
-//
-//	ALERT_OBJECT_DUPLICATE
-//	告警对象重复
-//	支持国际化输出
+//  ALERT_OBJECT_DUPLICATE
+//  告警对象重复
+//  支持国际化输出
 func ErrorI18nAlertAlertObjectDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警对象重复"
 	if len(args) > 0 {
@@ -766,10 +755,9 @@ var _AlertAlertLevelDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertLevelDuplicate 用于表单验证错误
-//
-//	ALERT_LEVEL_DUPLICATE
-//	策略告警等级重复
-//	支持国际化输出
+//  ALERT_LEVEL_DUPLICATE
+//  策略告警等级重复
+//  支持国际化输出
 func ErrorI18nAlertAlertLevelDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略告警等级重复"
 	if len(args) > 0 {
@@ -835,10 +823,9 @@ var _AlertEmailCaptchaErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertEmailCaptchaErr 用于表单验证错误
-//
-//	EMAIL_CAPTCHA_ERR
-//	邮箱验证码错误
-//	支持国际化输出
+//  EMAIL_CAPTCHA_ERR
+//  邮箱验证码错误
+//  支持国际化输出
 func ErrorI18nAlertEmailCaptchaErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "邮箱验证码错误"
 	if len(args) > 0 {
@@ -902,10 +889,9 @@ var _AlertSelectAlertPageErrMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertSelectAlertPageErr 用于表单验证错误
-//
-//	SELECT_ALERT_PAGE_ERR
-//	选择告警页面错误，请重新选择
-//	支持国际化输出
+//  SELECT_ALERT_PAGE_ERR
+//  选择告警页面错误，请重新选择
+//  支持国际化输出
 func ErrorI18nAlertSelectAlertPageErr(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "选择告警页面错误，请重新选择"
 	if len(args) > 0 {
@@ -969,10 +955,9 @@ var _AlertHookNameDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertHookNameDuplicate 用于表单验证错误
-//
-//	HOOK_NAME_DUPLICATE
-//	hook名称重复
-//	支持国际化输出
+//  HOOK_NAME_DUPLICATE
+//  hook名称重复
+//  支持国际化输出
 func ErrorI18nAlertHookNameDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "hook名称重复"
 	if len(args) > 0 {
@@ -1038,10 +1023,9 @@ var _AlertAlertGroupNameDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertGroupNameDuplicate 用于表单验证错误
-//
-//	ALERT_GROUP_NAME_DUPLICATE
-//	告警组名称重复
-//	支持国际化输出
+//  ALERT_GROUP_NAME_DUPLICATE
+//  告警组名称重复
+//  支持国际化输出
 func ErrorI18nAlertAlertGroupNameDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警组名称重复"
 	if len(args) > 0 {
@@ -1107,10 +1091,9 @@ var _AlertStrategyGroupNameDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyGroupNameDuplicate 用于表单验证错误
-//
-//	STRATEGY_GROUP_NAME_DUPLICATE
-//	策略组名称重复
-//	支持国际化输出
+//  STRATEGY_GROUP_NAME_DUPLICATE
+//  策略组名称重复
+//  支持国际化输出
 func ErrorI18nAlertStrategyGroupNameDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略组名称重复"
 	if len(args) > 0 {
@@ -1176,10 +1159,9 @@ var _AlertStrategyNameDuplicateMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyNameDuplicate 用于表单验证错误
-//
-//	STRATEGY_NAME_DUPLICATE
-//	策略名称重复
-//	支持国际化输出
+//  STRATEGY_NAME_DUPLICATE
+//  策略名称重复
+//  支持国际化输出
 func ErrorI18nAlertStrategyNameDuplicate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略名称重复"
 	if len(args) > 0 {
@@ -1245,10 +1227,9 @@ var _AlertStrategyGroupTypeNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyGroupTypeNotExist 用于表单验证错误
-//
-//	STRATEGY_GROUP_TYPE_NOT_EXIST
-//	策略组类型不存在
-//	支持国际化输出
+//  STRATEGY_GROUP_TYPE_NOT_EXIST
+//  策略组类型不存在
+//  支持国际化输出
 func ErrorI18nAlertStrategyGroupTypeNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略组类型不存在"
 	if len(args) > 0 {
@@ -1314,10 +1295,9 @@ var _AlertStrategyTypeNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyTypeNotExist 用于表单验证错误
-//
-//	STRATEGY_TYPE_NOT_EXIST
-//	策略分类不存在
-//	支持国际化输出
+//  STRATEGY_TYPE_NOT_EXIST
+//  策略分类不存在
+//  支持国际化输出
 func ErrorI18nAlertStrategyTypeNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略分类不存在"
 	if len(args) > 0 {
@@ -1381,10 +1361,9 @@ var _AlertAlertGroupNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertGroupNotFound 用于表单验证错误
-//
-//	ALERT_GROUP_NOT_FOUND
-//	告警组不存在
-//	支持国际化输出
+//  ALERT_GROUP_NOT_FOUND
+//  告警组不存在
+//  支持国际化输出
 func ErrorI18nAlertAlertGroupNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警组不存在"
 	if len(args) > 0 {
@@ -1446,10 +1425,9 @@ var _AlertStrategyGroupNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyGroupNotFound 用于表单验证错误
-//
-//	STRATEGY_GROUP_NOT_FOUND
-//	策略组不存在
-//	支持国际化输出
+//  STRATEGY_GROUP_NOT_FOUND
+//  策略组不存在
+//  支持国际化输出
 func ErrorI18nAlertStrategyGroupNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略组不存在"
 	if len(args) > 0 {
@@ -1511,10 +1489,9 @@ var _AlertDatasourceNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertDatasourceNotFound 用于表单验证错误
-//
-//	DATASOURCE_NOT_FOUND
-//	数据源不存在
-//	支持国际化输出
+//  DATASOURCE_NOT_FOUND
+//  数据源不存在
+//  支持国际化输出
 func ErrorI18nAlertDatasourceNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "数据源不存在"
 	if len(args) > 0 {
@@ -1576,10 +1553,9 @@ var _AlertAlertPageNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertPageNotFound 用于表单验证错误
-//
-//	ALERT_PAGE_NOT_FOUND
-//	告警页面不存在
-//	支持国际化输出
+//  ALERT_PAGE_NOT_FOUND
+//  告警页面不存在
+//  支持国际化输出
 func ErrorI18nAlertAlertPageNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警页面不存在"
 	if len(args) > 0 {
@@ -1641,10 +1617,9 @@ var _AlertAlertLevelNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertAlertLevelNotFound 用于表单验证错误
-//
-//	ALERT_LEVEL_NOT_FOUND
-//	告警等级不存在
-//	支持国际化输出
+//  ALERT_LEVEL_NOT_FOUND
+//  告警等级不存在
+//  支持国际化输出
 func ErrorI18nAlertAlertLevelNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警等级不存在"
 	if len(args) > 0 {
@@ -1706,10 +1681,9 @@ var _AlertStrategyTemplateNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nAlertStrategyTemplateNotFound 用于表单验证错误
-//
-//	STRATEGY_TEMPLATE_NOT_FOUND
-//	策略模板不存在
-//	支持国际化输出
+//  STRATEGY_TEMPLATE_NOT_FOUND
+//  策略模板不存在
+//  支持国际化输出
 func ErrorI18nAlertStrategyTemplateNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略模板不存在"
 	if len(args) > 0 {
@@ -1763,8 +1737,7 @@ var _ModalMsg = &i18n.Message{
 }
 
 // ErrorI18nModal 用于弹窗验证错误, 需要提供确认按钮和确认请求的幂等键
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nModal(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "请确认"
 	if len(args) > 0 {
@@ -1830,10 +1803,9 @@ var _ModalConfirmDeleteMsg = &i18n.Message{
 }
 
 // ErrorI18nModalConfirmDelete 用于弹窗验证错误, 需要提供确认按钮和确认请求的幂等键
-//
-//	CONFIRM_DELETE
-//	确认删除
-//	支持国际化输出
+//  CONFIRM_DELETE
+//  确认删除
+//  支持国际化输出
 func ErrorI18nModalConfirmDelete(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "确认删除"
 	if len(args) > 0 {
@@ -1903,10 +1875,9 @@ var _ModalConfirmUpdateMsg = &i18n.Message{
 }
 
 // ErrorI18nModalConfirmUpdate 用于弹窗验证错误, 需要提供确认按钮和确认请求的幂等键
-//
-//	CONFIRM_UPDATE
-//	确认修改
-//	支持国际化输出
+//  CONFIRM_UPDATE
+//  确认修改
+//  支持国际化输出
 func ErrorI18nModalConfirmUpdate(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "确认修改"
 	if len(args) > 0 {
@@ -1964,8 +1935,7 @@ var _ToastMsg = &i18n.Message{
 }
 
 // ErrorI18nToast 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nToast(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "资源不存在"
 	if len(args) > 0 {
@@ -2027,10 +1997,9 @@ var _ToastResourceNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastResourceNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	RESOURCE_NOT_FOUND
-//	资源不存在
-//	支持国际化输出
+//  RESOURCE_NOT_FOUND
+//  资源不存在
+//  支持国际化输出
 func ErrorI18nToastResourceNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "资源不存在"
 	if len(args) > 0 {
@@ -2092,10 +2061,9 @@ var _ToastResourceExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastResourceExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	RESOURCE_EXIST
-//	资源已存在
-//	支持国际化输出
+//  RESOURCE_EXIST
+//  资源已存在
+//  支持国际化输出
 func ErrorI18nToastResourceExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "资源已存在"
 	if len(args) > 0 {
@@ -2157,10 +2125,9 @@ var _ToastUserNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_FOUND
-//	用户不存在
-//	支持国际化输出
+//  USER_NOT_FOUND
+//  用户不存在
+//  支持国际化输出
 func ErrorI18nToastUserNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "用户不存在"
 	if len(args) > 0 {
@@ -2222,10 +2189,9 @@ var _ToastUsernameExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUsernameExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USERNAME_EXIST
-//	用户名已存在
-//	支持国际化输出
+//  USERNAME_EXIST
+//  用户名已存在
+//  支持国际化输出
 func ErrorI18nToastUsernameExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "用户名已存在"
 	if len(args) > 0 {
@@ -2287,10 +2253,9 @@ var _ToastAlertGroupNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastAlertGroupNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ALERT_GROUP_NOT_FOUND
-//	告警组不存在
-//	支持国际化输出
+//  ALERT_GROUP_NOT_FOUND
+//  告警组不存在
+//  支持国际化输出
 func ErrorI18nToastAlertGroupNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警组不存在"
 	if len(args) > 0 {
@@ -2352,10 +2317,9 @@ var _ToastDatasourceSyncingMsg = &i18n.Message{
 }
 
 // ErrorI18nToastDatasourceSyncing 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	DATASOURCE_SYNCING
-//	数据源同步中
-//	支持国际化输出
+//  DATASOURCE_SYNCING
+//  数据源同步中
+//  支持国际化输出
 func ErrorI18nToastDatasourceSyncing(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "数据源同步中"
 	if len(args) > 0 {
@@ -2417,10 +2381,9 @@ var _ToastUserNotSubscribeMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotSubscribe 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_SUBSCRIBE
-//	用户未订阅此策略
-//	支持国际化输出
+//  USER_NOT_SUBSCRIBE
+//  用户未订阅此策略
+//  支持国际化输出
 func ErrorI18nToastUserNotSubscribe(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "用户未订阅此策略"
 	if len(args) > 0 {
@@ -2482,10 +2445,9 @@ var _ToastTeamNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastTeamNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	TEAM_NOT_FOUND
-//	团队不存在
-//	支持国际化输出
+//  TEAM_NOT_FOUND
+//  团队不存在
+//  支持国际化输出
 func ErrorI18nToastTeamNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "团队不存在"
 	if len(args) > 0 {
@@ -2547,10 +2509,9 @@ var _ToastUserNotAllowRemoveSelfMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotAllowRemoveSelf 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_ALLOW_REMOVE_SELF
-//	不允许移除自己
-//	支持国际化输出
+//  USER_NOT_ALLOW_REMOVE_SELF
+//  不允许移除自己
+//  支持国际化输出
 func ErrorI18nToastUserNotAllowRemoveSelf(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不允许移除自己"
 	if len(args) > 0 {
@@ -2612,10 +2573,9 @@ var _ToastUserNotAllowRemoveAdminMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotAllowRemoveAdmin 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_ALLOW_REMOVE_ADMIN
-//	不允许移除团队管理员
-//	支持国际化输出
+//  USER_NOT_ALLOW_REMOVE_ADMIN
+//  不允许移除团队管理员
+//  支持国际化输出
 func ErrorI18nToastUserNotAllowRemoveAdmin(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不允许移除团队管理员"
 	if len(args) > 0 {
@@ -2677,10 +2637,9 @@ var _ToastUserNotAllowOperateAdminMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotAllowOperateAdmin 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_ALLOW_OPERATE_ADMIN
-//	不允许操作自己的管理员身份
-//	支持国际化输出
+//  USER_NOT_ALLOW_OPERATE_ADMIN
+//  不允许操作自己的管理员身份
+//  支持国际化输出
 func ErrorI18nToastUserNotAllowOperateAdmin(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不允许操作自己的管理员身份"
 	if len(args) > 0 {
@@ -2742,10 +2701,9 @@ var _ToastRoleNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastRoleNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ROLE_NOT_FOUND
-//	角色不存在
-//	支持国际化输出
+//  ROLE_NOT_FOUND
+//  角色不存在
+//  支持国际化输出
 func ErrorI18nToastRoleNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "角色不存在"
 	if len(args) > 0 {
@@ -2807,10 +2765,9 @@ var _ToastTemplateStrategyNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastTemplateStrategyNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	TEMPLATE_STRATEGY_NOT_FOUND
-//	策略模板不存在
-//	支持国际化输出
+//  TEMPLATE_STRATEGY_NOT_FOUND
+//  策略模板不存在
+//  支持国际化输出
 func ErrorI18nToastTemplateStrategyNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略模板不存在"
 	if len(args) > 0 {
@@ -2872,10 +2829,9 @@ var _ToastUserNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserNotExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_NOT_EXIST
-//	用户不存在
-//	支持国际化输出
+//  USER_NOT_EXIST
+//  用户不存在
+//  支持国际化输出
 func ErrorI18nToastUserNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "用户不存在"
 	if len(args) > 0 {
@@ -2937,10 +2893,9 @@ var _ToastDashboardNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastDashboardNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	DASHBOARD_NOT_FOUND
-//	图表大盘不存在
-//	支持国际化输出
+//  DASHBOARD_NOT_FOUND
+//  图表大盘不存在
+//  支持国际化输出
 func ErrorI18nToastDashboardNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "图表大盘不存在"
 	if len(args) > 0 {
@@ -3002,10 +2957,9 @@ var _ToastRealtimeAlarmNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastRealtimeAlarmNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	REALTIME_ALARM_NOT_FOUND
-//	实时告警不存在
-//	支持国际化输出
+//  REALTIME_ALARM_NOT_FOUND
+//  实时告警不存在
+//  支持国际化输出
 func ErrorI18nToastRealtimeAlarmNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "实时告警不存在"
 	if len(args) > 0 {
@@ -3067,10 +3021,9 @@ var _ToastHistoryAlarmNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastHistoryAlarmNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	HISTORY_ALARM_NOT_FOUND
-//	历史告警不存在
-//	支持国际化输出
+//  HISTORY_ALARM_NOT_FOUND
+//  历史告警不存在
+//  支持国际化输出
 func ErrorI18nToastHistoryAlarmNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "历史告警不存在"
 	if len(args) > 0 {
@@ -3134,10 +3087,9 @@ var _ToastDataSourceNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastDataSourceNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	DATA_SOURCE_NOT_FOUND
-//	数据源不存在
-//	支持国际化输出
+//  DATA_SOURCE_NOT_FOUND
+//  数据源不存在
+//  支持国际化输出
 func ErrorI18nToastDataSourceNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "数据源不存在"
 	if len(args) > 0 {
@@ -3203,10 +3155,9 @@ var _ToastDictNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastDictNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	DICT_NOT_FOUND
-//	字典不存在
-//	支持国际化输出
+//  DICT_NOT_FOUND
+//  字典不存在
+//  支持国际化输出
 func ErrorI18nToastDictNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "字典不存在"
 	if len(args) > 0 {
@@ -3272,10 +3223,9 @@ var _ToastAlarmHookNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastAlarmHookNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ALARM_HOOK_NOT_FOUND
-//	告警hook不存在
-//	支持国际化输出
+//  ALARM_HOOK_NOT_FOUND
+//  告警hook不存在
+//  支持国际化输出
 func ErrorI18nToastAlarmHookNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警hook不存在"
 	if len(args) > 0 {
@@ -3341,10 +3291,9 @@ var _ToastAlarmTemplateNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastAlarmTemplateNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ALARM_TEMPLATE_NOT_FOUND
-//	告警模板不存在
-//	支持国际化输出
+//  ALARM_TEMPLATE_NOT_FOUND
+//  告警模板不存在
+//  支持国际化输出
 func ErrorI18nToastAlarmTemplateNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警模板不存在"
 	if len(args) > 0 {
@@ -3410,10 +3359,9 @@ var _ToastMenuNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastMenuNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	MENU_NOT_FOUND
-//	菜单不存在
-//	支持国际化输出
+//  MENU_NOT_FOUND
+//  菜单不存在
+//  支持国际化输出
 func ErrorI18nToastMenuNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "菜单不存在"
 	if len(args) > 0 {
@@ -3479,10 +3427,9 @@ var _ToastMetricNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastMetricNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	METRIC_NOT_FOUND
-//	指标不存在
-//	支持国际化输出
+//  METRIC_NOT_FOUND
+//  指标不存在
+//  支持国际化输出
 func ErrorI18nToastMetricNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "指标不存在"
 	if len(args) > 0 {
@@ -3548,10 +3495,9 @@ var _ToastApiNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastApiNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	API_NOT_FOUND
-//	API不存在
-//	支持国际化输出
+//  API_NOT_FOUND
+//  API不存在
+//  支持国际化输出
 func ErrorI18nToastApiNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "API不存在"
 	if len(args) > 0 {
@@ -3617,10 +3563,9 @@ var _ToastStrategyNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastStrategyNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	STRATEGY_NOT_FOUND
-//	告警策略不存在
-//	支持国际化输出
+//  STRATEGY_NOT_FOUND
+//  告警策略不存在
+//  支持国际化输出
 func ErrorI18nToastStrategyNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警策略不存在"
 	if len(args) > 0 {
@@ -3686,10 +3631,9 @@ var _ToastStrategyGroupNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastStrategyGroupNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	STRATEGY_GROUP_NOT_FOUND
-//	策略组不存在
-//	支持国际化输出
+//  STRATEGY_GROUP_NOT_FOUND
+//  策略组不存在
+//  支持国际化输出
 func ErrorI18nToastStrategyGroupNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略组不存在"
 	if len(args) > 0 {
@@ -3755,10 +3699,9 @@ var _ToastTeamInviteAlreadyExistsMsg = &i18n.Message{
 }
 
 // ErrorI18nToastTeamInviteAlreadyExists 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	TEAM_INVITE_ALREADY_EXISTS
-//	%s,邀请记录已存在,或者已经加入团队!
-//	支持国际化输出
+//  TEAM_INVITE_ALREADY_EXISTS
+//  %s,邀请记录已存在,或者已经加入团队!
+//  支持国际化输出
 func ErrorI18nToastTeamInviteAlreadyExists(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "%s,邀请记录已存在,或者已经加入团队!"
 	if len(args) > 0 {
@@ -3824,10 +3767,9 @@ var _ToastTeamInviteNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastTeamInviteNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	TEAM_INVITE_NOT_FOUND
-//	邀请记录不存在
-//	支持国际化输出
+//  TEAM_INVITE_NOT_FOUND
+//  邀请记录不存在
+//  支持国际化输出
 func ErrorI18nToastTeamInviteNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "邀请记录不存在"
 	if len(args) > 0 {
@@ -3893,10 +3835,9 @@ var _ToastAlarmSendHistoryNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastAlarmSendHistoryNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ALARM_SEND_HISTORY_NOT_FOUND
-//	告警发送历史不存在
-//	支持国际化输出
+//  ALARM_SEND_HISTORY_NOT_FOUND
+//  告警发送历史不存在
+//  支持国际化输出
 func ErrorI18nToastAlarmSendHistoryNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "告警发送历史不存在"
 	if len(args) > 0 {
@@ -3960,10 +3901,9 @@ var _ToastRoleHasRelationMsg = &i18n.Message{
 }
 
 // ErrorI18nToastRoleHasRelation 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	ROLE_HAS_RELATION
-//	角色存在关联关系
-//	支持国际化输出
+//  ROLE_HAS_RELATION
+//  角色存在关联关系
+//  支持国际化输出
 func ErrorI18nToastRoleHasRelation(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "角色存在关联关系"
 	if len(args) > 0 {
@@ -4025,10 +3965,9 @@ var _ToastTeamMemberNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastTeamMemberNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	TEAM_MEMBER_NOT_FOUND
-//	团队成员不存在
-//	支持国际化输出
+//  TEAM_MEMBER_NOT_FOUND
+//  团队成员不存在
+//  支持国际化输出
 func ErrorI18nToastTeamMemberNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "团队成员不存在"
 	if len(args) > 0 {
@@ -4090,10 +4029,9 @@ var _ToastUserMessageNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nToastUserMessageNotFound 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	USER_MESSAGE_NOT_FOUND
-//	消息不存在
-//	支持国际化输出
+//  USER_MESSAGE_NOT_FOUND
+//  消息不存在
+//  支持国际化输出
 func ErrorI18nToastUserMessageNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "消息不存在"
 	if len(args) > 0 {
@@ -4157,10 +4095,9 @@ var _ToastStrategyTypeNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastStrategyTypeNotExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	STRATEGY_TYPE_NOT_EXIST
-//	策略类型不存在
-//	支持国际化输出
+//  STRATEGY_TYPE_NOT_EXIST
+//  策略类型不存在
+//  支持国际化输出
 func ErrorI18nToastStrategyTypeNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "策略类型不存在"
 	if len(args) > 0 {
@@ -4226,10 +4163,9 @@ var _ToastSendTemplateTypeNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastSendTemplateTypeNotExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	SEND_TEMPLATE_TYPE_NOT_EXIST
-//	发送模板不存在
-//	支持国际化输出
+//  SEND_TEMPLATE_TYPE_NOT_EXIST
+//  发送模板不存在
+//  支持国际化输出
 func ErrorI18nToastSendTemplateTypeNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "发送模板不存在"
 	if len(args) > 0 {
@@ -4295,10 +4231,9 @@ var _ToastSendTemplateNameExistMsg = &i18n.Message{
 }
 
 // ErrorI18nToastSendTemplateNameExist 用于toast验证错误， 资源不存在或者已存在时候提示
-//
-//	SEND_TEMPLATE_NAME_EXIST
-//	发送模板名称{%s}已经存在!
-//	支持国际化输出
+//  SEND_TEMPLATE_NAME_EXIST
+//  发送模板名称{%s}已经存在!
+//  支持国际化输出
 func ErrorI18nToastSendTemplateNameExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "发送模板名称{%s}已经存在!"
 	if len(args) > 0 {
@@ -4354,8 +4289,7 @@ var _NotificationMsg = &i18n.Message{
 }
 
 // ErrorI18nNotification 用于通知验证错误， 系统级别错误
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nNotification(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "服务器可能遇到了意外，非常抱歉！"
 	if len(args) > 0 {
@@ -4417,10 +4351,9 @@ var _NotificationSystemErrorMsg = &i18n.Message{
 }
 
 // ErrorI18nNotificationSystemError 用于通知验证错误， 系统级别错误
-//
-//	SYSTEM_ERROR
-//	服务器遭遇了外星人攻击，攻城狮和程序猿们正在抢修......
-//	支持国际化输出
+//  SYSTEM_ERROR
+//  服务器遭遇了外星人攻击，攻城狮和程序猿们正在抢修......
+//  支持国际化输出
 func ErrorI18nNotificationSystemError(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "服务器遭遇了外星人攻击，攻城狮和程序猿们正在抢修......"
 	if len(args) > 0 {
@@ -4482,10 +4415,9 @@ var _NotificationUnsupportedDataSourceMsg = &i18n.Message{
 }
 
 // ErrorI18nNotificationUnsupportedDataSource 用于通知验证错误， 系统级别错误
-//
-//	UNSUPPORTED_DATA_SOURCE
-//	不支持的数据源类型
-//	支持国际化输出
+//  UNSUPPORTED_DATA_SOURCE
+//  不支持的数据源类型
+//  支持国际化输出
 func ErrorI18nNotificationUnsupportedDataSource(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不支持的数据源类型"
 	if len(args) > 0 {
@@ -4547,10 +4479,9 @@ var _NotificationDataSourceConfigurationErrorMsg = &i18n.Message{
 }
 
 // ErrorI18nNotificationDataSourceConfigurationError 用于通知验证错误， 系统级别错误
-//
-//	DATA_SOURCE_CONFIGURATION_ERROR
-//	数据源配置错误,请检查数据格式!
-//	支持国际化输出
+//  DATA_SOURCE_CONFIGURATION_ERROR
+//  数据源配置错误,请检查数据格式!
+//  支持国际化输出
 func ErrorI18nNotificationDataSourceConfigurationError(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "数据源配置错误,请检查数据格式!"
 	if len(args) > 0 {
@@ -4606,8 +4537,7 @@ var _UnauthorizedMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorized 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nUnauthorized(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "请先登录"
 	if len(args) > 0 {
@@ -4673,10 +4603,9 @@ var _UnauthorizedJwtExpireMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorizedJwtExpire 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	JWT_EXPIRE
-//	登录已过期
-//	支持国际化输出
+//  JWT_EXPIRE
+//  登录已过期
+//  支持国际化输出
 func ErrorI18nUnauthorizedJwtExpire(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "登录已过期"
 	if len(args) > 0 {
@@ -4742,10 +4671,9 @@ var _UnauthorizedJwtOtherLoginMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorizedJwtOtherLogin 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	JWT_OTHER_LOGIN
-//	账号已在其他地方登录
-//	支持国际化输出
+//  JWT_OTHER_LOGIN
+//  账号已在其他地方登录
+//  支持国际化输出
 func ErrorI18nUnauthorizedJwtOtherLogin(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "账号已在其他地方登录"
 	if len(args) > 0 {
@@ -4811,10 +4739,9 @@ var _UnauthorizedJwtBanMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorizedJwtBan 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	JWT_BAN
-//	认证信息已登出，请重新登录
-//	支持国际化输出
+//  JWT_BAN
+//  认证信息已登出，请重新登录
+//  支持国际化输出
 func ErrorI18nUnauthorizedJwtBan(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "认证信息已登出，请重新登录"
 	if len(args) > 0 {
@@ -4880,10 +4807,9 @@ var _UnauthorizedUserNotFoundMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorizedUserNotFound 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	USER_NOT_FOUND
-//	账号不存在
-//	支持国际化输出
+//  USER_NOT_FOUND
+//  账号不存在
+//  支持国际化输出
 func ErrorI18nUnauthorizedUserNotFound(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "账号不存在"
 	if len(args) > 0 {
@@ -4949,10 +4875,9 @@ var _UnauthorizedUserBanMsg = &i18n.Message{
 }
 
 // ErrorI18nUnauthorizedUserBan 用于重定向验证错误, 跳转到指定页面， 认证级别提示
-//
-//	USER_BAN
-//	您已被禁止使用该系统，请联系官方解除
-//	支持国际化输出
+//  USER_BAN
+//  您已被禁止使用该系统，请联系官方解除
+//  支持国际化输出
 func ErrorI18nUnauthorizedUserBan(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "您已被禁止使用该系统，请联系官方解除"
 	if len(args) > 0 {
@@ -5008,8 +4933,7 @@ var _ForbiddenMsg = &i18n.Message{
 }
 
 // ErrorI18nForbidden 权限不足时候提示, toast提示 权限级别提示
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nForbidden(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "您没有操作权限, 请联系管理员开通该权限"
 	if len(args) > 0 {
@@ -5071,10 +4995,9 @@ var _ForbiddenUserNotInTeamMsg = &i18n.Message{
 }
 
 // ErrorI18nForbiddenUserNotInTeam 权限不足时候提示, toast提示 权限级别提示
-//
-//	USER_NOT_IN_TEAM
-//	您已不属于该团队
-//	支持国际化输出
+//  USER_NOT_IN_TEAM
+//  您已不属于该团队
+//  支持国际化输出
 func ErrorI18nForbiddenUserNotInTeam(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "您已不属于该团队"
 	if len(args) > 0 {
@@ -5136,10 +5059,9 @@ var _ForbiddenMemberDisabledMsg = &i18n.Message{
 }
 
 // ErrorI18nForbiddenMemberDisabled 权限不足时候提示, toast提示 权限级别提示
-//
-//	MEMBER_DISABLED
-//	您已被该团队禁用操作，请联系管理员
-//	支持国际化输出
+//  MEMBER_DISABLED
+//  您已被该团队禁用操作，请联系管理员
+//  支持国际化输出
 func ErrorI18nForbiddenMemberDisabled(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "您已被该团队禁用操作，请联系管理员"
 	if len(args) > 0 {
@@ -5201,10 +5123,9 @@ var _ForbiddenPermissionDeniedMsg = &i18n.Message{
 }
 
 // ErrorI18nForbiddenPermissionDenied 权限不足时候提示, toast提示 权限级别提示
-//
-//	PERMISSION_DENIED
-//	您的权限不足以操作此数据
-//	支持国际化输出
+//  PERMISSION_DENIED
+//  您的权限不足以操作此数据
+//  支持国际化输出
 func ErrorI18nForbiddenPermissionDenied(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "您的权限不足以操作此数据"
 	if len(args) > 0 {
@@ -5266,10 +5187,9 @@ var _ForbiddenCannotSetEqualPermissionMsg = &i18n.Message{
 }
 
 // ErrorI18nForbiddenCannotSetEqualPermission 权限不足时候提示, toast提示 权限级别提示
-//
-//	CANNOT_SET_EQUAL_PERMISSION
-//	不能设置成同等权限
-//	支持国际化输出
+//  CANNOT_SET_EQUAL_PERMISSION
+//  不能设置成同等权限
+//  支持国际化输出
 func ErrorI18nForbiddenCannotSetEqualPermission(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不能设置成同等权限"
 	if len(args) > 0 {
@@ -5323,8 +5243,7 @@ var _TooManyRequestsMsg = &i18n.Message{
 }
 
 // ErrorI18nTooManyRequests 触发频率限制
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nTooManyRequests(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "请求太频繁，请稍后再试"
 	if len(args) > 0 {
@@ -5378,8 +5297,7 @@ var _FileRelatedMsg = &i18n.Message{
 }
 
 // ErrorI18nFileRelated 文件相关
-//
-//	支持国际化输出
+//  支持国际化输出
 func ErrorI18nFileRelated(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "文件相关异常"
 	if len(args) > 0 {
@@ -5441,10 +5359,9 @@ var _FileRelatedFileContentDoesNotExistMsg = &i18n.Message{
 }
 
 // ErrorI18nFileRelatedFileContentDoesNotExist 文件相关
-//
-//	FILE_CONTENT_DOES_NOT_EXIST
-//	文件:[%s]内容不存在！
-//	支持国际化输出
+//  FILE_CONTENT_DOES_NOT_EXIST
+//  文件:[%s]内容不存在！
+//  支持国际化输出
 func ErrorI18nFileRelatedFileContentDoesNotExist(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "文件:[%s]内容不存在！"
 	if len(args) > 0 {
@@ -5506,10 +5423,9 @@ var _FileRelatedFileNotSupportedUploadMsg = &i18n.Message{
 }
 
 // ErrorI18nFileRelatedFileNotSupportedUpload 文件相关
-//
-//	FILE_NOT_SUPPORTED_UPLOAD
-//	不支持该文件类型：%s上传
-//	支持国际化输出
+//  FILE_NOT_SUPPORTED_UPLOAD
+//  不支持该文件类型：%s上传
+//  支持国际化输出
 func ErrorI18nFileRelatedFileNotSupportedUpload(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "不支持该文件类型：%s上传"
 	if len(args) > 0 {
@@ -5571,10 +5487,9 @@ var _FileRelatedFileMaximumLimitMsg = &i18n.Message{
 }
 
 // ErrorI18nFileRelatedFileMaximumLimit 文件相关
-//
-//	FILE_MAXIMUM_LIMIT
-//	该类型[%s]文件大小超过最大限制!
-//	支持国际化输出
+//  FILE_MAXIMUM_LIMIT
+//  该类型[%s]文件大小超过最大限制!
+//  支持国际化输出
 func ErrorI18nFileRelatedFileMaximumLimit(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "该类型[%s]文件大小超过最大限制!"
 	if len(args) > 0 {
@@ -5636,10 +5551,9 @@ var _FileRelatedOssNotOpenedMsg = &i18n.Message{
 }
 
 // ErrorI18nFileRelatedOssNotOpened 文件相关
-//
-//	OSS_NOT_OPENED
-//	oss未打开,不允许上传文件!
-//	支持国际化输出
+//  OSS_NOT_OPENED
+//  oss未打开,不允许上传文件!
+//  支持国际化输出
 func ErrorI18nFileRelatedOssNotOpened(ctx context.Context, args ...interface{}) *errors.Error {
 	msg := "oss未打开,不允许上传文件!"
 	if len(args) > 0 {

--- a/pkg/vobj/sendstatus.go
+++ b/pkg/vobj/sendstatus.go
@@ -9,9 +9,23 @@ const (
 	// SendStatusUnknown 未知
 	SendStatusUnknown SendStatus = iota // 未知
 	// Sending 发送中
-	Sending
+	Sending // 发送中
 	// SentSuccess 发送成功
-	SentSuccess
+	SentSuccess // 发送成功
 	// SendFail 发送失败
-	SendFail
+	SendFail // 发送失败
 )
+
+// EnString 转换为字符串
+func (s SendStatus) EnString() string {
+	switch s {
+	case Sending:
+		return "sending"
+	case SentSuccess:
+		return "sent_success"
+	case SendFail:
+		return "send_fail"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
- 在 send_alert.go 中增加了对无效 route 的日志记录和监控指标
- 在 alert.go 中添加了告警相关的监控指标，包括计数器和实时计数
- 新增了 counter_alarm、counter_notify 和 gauge_alarm 三个监控指标文件
- 在 sendstatus.go 中为 SendStatus 类型添加了字符串转换方法