### PR TITLE
refactor(auth): remove team ID from JWT and use request headers instead

### DIFF
--- a/cmd/server/palace/internal/biz/bo/authorization.go
+++ b/cmd/server/palace/internal/biz/bo/authorization.go
@@ -44,5 +44,4 @@ type RefreshTokenParams struct {
 type RefreshTokenReply struct {
 	JwtClaims *middleware.JwtClaims
 	User      *model.SysUser
-	TeamID    uint32 `json:"teamID"`
 }

--- a/cmd/server/palace/internal/data/init.go
+++ b/cmd/server/palace/internal/data/init.go
@@ -21,9 +21,9 @@ func initMainDatabase(d *Data) error {
 	if env.Env() != "dev" {
 		return nil
 	}
-	if err := d.mainDB.AutoMigrate(model.Models()...); err != nil {
-		return err
-	}
+	//if err := d.mainDB.AutoMigrate(model.Models()...); err != nil {
+	//	return err
+	//}
 
 	if err := query.Use(d.mainDB).SysDict.Clauses(clause.OnConflict{DoNothing: true}).Create(defaultDictList...); err != nil {
 		return err

--- a/cmd/server/palace/internal/service/authorization/authorization.go
+++ b/cmd/server/palace/internal/service/authorization/authorization.go
@@ -118,7 +118,7 @@ func (s *Service) RefreshToken(ctx context.Context, req *authorizationapi.Refres
 	return &authorizationapi.RefreshTokenReply{
 		Token:  token,
 		User:   builder.NewParamsBuild(ctx).UserModuleBuilder().DoUserBuilder().ToAPI(tokenRes.User),
-		TeamID: tokenRes.TeamID,
+		TeamID: req.GetTeamID(),
 	}, nil
 }
 


### PR DESCRIPTION
- Remove TeamID field from JwtBaseInfo and RefreshTokenReply structs
- Use X-Team-ID and X-Team-Member-ID request headers to set team context
- Update authorization logic to use new header-based team identification
- Remove unnecessary context setters for team ID and member ID
