### PR TITLE
feat(cache): Optimize Redis connection configuration

### DIFF
--- a/cmd/palace/config/data.yaml
+++ b/cmd/palace/config/data.yaml
@@ -14,7 +14,7 @@ cache:
   driver: ${X_MOON_CACHE_DRIVER:MEMORY}
   network: ${X_MOON_CACHE_NETWORK:tcp}
   addr: ${X_MOON_CACHE_ADDR:127.0.0.1:6379}
-  password: ${X_MOON_CACHE_PASSWORD}
+  password: ${X_MOON_CACHE_PASSWORD:redis}
   db: ${X_MOON_CACHE_DB:0}
   readTimeout: ${X_MOON_CACHE_READ_TIMEOUT:5s}
   writeTimeout: ${X_MOON_CACHE_WRITE_TIMEOUT:5s}

--- a/pkg/plugin/cache/cache.go
+++ b/pkg/plugin/cache/cache.go
@@ -64,8 +64,6 @@ func newRedisWithMiniRedis(c *config.Cache) (*redis.Client, error) {
 	options := newDefaultOptions(c)
 	options.Network = "tcp"
 	options.Addr = cli.Addr()
-	options.Username = ""
-	options.Password = ""
 	return redis.NewClient(options), nil
 }
 
@@ -77,8 +75,8 @@ func newDefaultOptions(c *config.Cache) *redis.Options {
 		Dialer:                     nil,
 		OnConnect:                  nil,
 		Protocol:                   int(c.GetProtocol()),
-		Username:                   "",
-		Password:                   "redis",
+		Username:                   c.GetUsername(),
+		Password:                   c.GetPassword(),
 		CredentialsProvider:        nil,
 		CredentialsProviderContext: nil,
 		DB:                         int(c.GetDb()),


### PR DESCRIPTION
Remove redundant Username and Password settings in newDefaultOptions Use c.GetUsername() and c.GetPassword() to get authentication information when creating redis.Options Update config/data.yaml to add default value "redis" for X_MOON_CACHE_PASSWORD